### PR TITLE
Update grog to v0.9.4

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.9.3"
+  version "v0.9.4"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.3/grog-darwin-arm64"
-      sha256 "af2678c5724102326ded78b9a1aa25ea25082a17186df02f8fb6ab6b61f1962a"
+      url "https://github.com/chrismatix/grog/releases/download/v0.9.4/grog-darwin-arm64"
+      sha256 "f522e0bc982fbb3fd0f4ebffc0d1bce71369a6bb989b5ba197dd41e4dd5af264"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.3/grog-darwin-amd64"
-      sha256 "e7633a4706b21417360a780ed5fb677b16886dded222f7931314a2cf988bb35f"
+      url "https://github.com/chrismatix/grog/releases/download/v0.9.4/grog-darwin-amd64"
+      sha256 "4b850b7f24035c91fe2f1ffb66d3589d1ee4821c7a2f295a48636898e125557a"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.3/grog-linux-arm64"
-      sha256 "5afa998b5be5e513871204f9c503e14a0bcbe1f55289f48d083c83b71e07652c"
+      url "https://github.com/chrismatix/grog/releases/download/v0.9.4/grog-linux-arm64"
+      sha256 "ab74e4acd7e2ee9b94751a0dbf91f401a982d6b90480ba1130f89dbf3e612c4d"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.3/grog-linux-amd64"
-      sha256 "3e9e35fbe21281fc310ee75be72200bcc8dd6aed4f73d79a6712a91f9e1665e5"
+      url "https://github.com/chrismatix/grog/releases/download/v0.9.4/grog-linux-amd64"
+      sha256 "ce9633151fdb899b8dda4ee70691d18a40cc517901a4cf9963d701e88c8fe675"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.9.4.

**Changes:**
- Updated version to v0.9.4
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.9.4