### PR TITLE
Update grog to v0.10.0

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.9.5"
+  version "v0.10.0"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.5/grog-darwin-arm64"
-      sha256 "7897c0bd1c1c6473821fb564fb3ec710e7edf95376b55141e1136e00cf896835"
+      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-darwin-arm64"
+      sha256 "b914a3b8926eae166ac2d86b9ca5dc339be732e6f5859fd2f386a2a8d5c25a97"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.5/grog-darwin-amd64"
-      sha256 "616bb5e2e37b733e2ec2dfcd4d85c69ccd4a250188f0d05438dc7fc76d15cc43"
+      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-darwin-amd64"
+      sha256 "46527894251f3144d6031c56803fdc9f07021b2a6c6a2089777f4ebbef7c9a54"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.5/grog-linux-arm64"
-      sha256 "8f28fb16353f0a8e3dca219a8064a17ec21d8f547bd9bd5da9ac547a17214936"
+      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-linux-arm64"
+      sha256 "fcf6047c1e420605b30092c733cf1eb50f7314db8c0e7a30ef4e663e252f19ef"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.9.5/grog-linux-amd64"
-      sha256 "0e86a4c51a5d51ec3463a285063a1c53ac6c71a9ac06bf9629e5b4be0e9e5e4b"
+      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-linux-amd64"
+      sha256 "f1baf4c5427f2f057492df9394b55d6f677913ec1cc27e4d89b87ec87f22e11b"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.10.0.

**Changes:**
- Updated version to v0.10.0
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.10.0