### PR TITLE
Update grog to v0.11.0

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.10.0"
+  version "v0.11.0"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-darwin-arm64"
-      sha256 "b914a3b8926eae166ac2d86b9ca5dc339be732e6f5859fd2f386a2a8d5c25a97"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-darwin-arm64"
+      sha256 "9f7235850cbc09191229c37bd12a408242037627a60e75d1036e6213e1aa387f"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-darwin-amd64"
-      sha256 "46527894251f3144d6031c56803fdc9f07021b2a6c6a2089777f4ebbef7c9a54"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-darwin-amd64"
+      sha256 "cf4263e9cad81ea21745844d544d75bed6a2d3cbe2637a9f2e118ce9f0b64c74"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-linux-arm64"
-      sha256 "fcf6047c1e420605b30092c733cf1eb50f7314db8c0e7a30ef4e663e252f19ef"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-linux-arm64"
+      sha256 "6cd85abc0933e82df49c7fc858fcb66d8d01038b0ef5fce5d007ab8b599a6911"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.10.0/grog-linux-amd64"
-      sha256 "f1baf4c5427f2f057492df9394b55d6f677913ec1cc27e4d89b87ec87f22e11b"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-linux-amd64"
+      sha256 "efbcabbabcd27d7e34708da89a6c77f256085e8e7c0482bea9ec03708447e65e"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.11.0.

**Changes:**
- Updated version to v0.11.0
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.11.0