### PR TITLE
Update grog to v0.11.1

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.11.0"
+  version "v0.11.1"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-darwin-arm64"
-      sha256 "9f7235850cbc09191229c37bd12a408242037627a60e75d1036e6213e1aa387f"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.1/grog-darwin-arm64"
+      sha256 "ad972c8fa61d96e8de92183b6a86fd5cdc9bff8c84a49e5a6a335a0ebcb3172a"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-darwin-amd64"
-      sha256 "cf4263e9cad81ea21745844d544d75bed6a2d3cbe2637a9f2e118ce9f0b64c74"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.1/grog-darwin-amd64"
+      sha256 "71994d366fa913b95a9fc0126f5119848d1d6a590cd59700307822bb469e930c"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-linux-arm64"
-      sha256 "6cd85abc0933e82df49c7fc858fcb66d8d01038b0ef5fce5d007ab8b599a6911"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.1/grog-linux-arm64"
+      sha256 "da64375cf589feef34124051eb1e20d9a03a9b44254e73b9671af6c6a3f88c80"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.11.0/grog-linux-amd64"
-      sha256 "efbcabbabcd27d7e34708da89a6c77f256085e8e7c0482bea9ec03708447e65e"
+      url "https://github.com/chrismatix/grog/releases/download/v0.11.1/grog-linux-amd64"
+      sha256 "5f324f83bf37a3d3d9b7022a42b4f1d50b79b59398f8745ead73b7f7310a45fc"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.11.1.

**Changes:**
- Updated version to v0.11.1
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.11.1