### PR TITLE
Update grog to v0.13.0

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.12.0"
+  version "v0.13.0"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.12.0/grog-darwin-arm64"
-      sha256 "1bc272cb8f2980dce5e356537343399fc8dce903602f343ba1951fa645a84db4"
+      url "https://github.com/chrismatix/grog/releases/download/v0.13.0/grog-darwin-arm64"
+      sha256 "f8afe2fa8c8ef9e2914d75ca1ba3d19d2094a38171f0767386f1d588d36c2a19"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.12.0/grog-darwin-amd64"
-      sha256 "5da5267dbb3811381f77eac6fe2f8d5a56da3f049a7eccd2282159d9ab3743b6"
+      url "https://github.com/chrismatix/grog/releases/download/v0.13.0/grog-darwin-amd64"
+      sha256 "18a99b0680906ed4b66eafdd3bd8e7c2d28eede9a930095521172eb1a9eff9d6"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.12.0/grog-linux-arm64"
-      sha256 "1a13480dc3fd599287abec19ec4f2541015ac311bc571a5906cc184b5ce52452"
+      url "https://github.com/chrismatix/grog/releases/download/v0.13.0/grog-linux-arm64"
+      sha256 "02df6876f5159101aa1d31ac59a02397aced82f9d300971298ea81936b98dacf"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.12.0/grog-linux-amd64"
-      sha256 "7891f9b697cddeffb7a23e2e2806d32608c8e9896f85e2d6861410c90083bf77"
+      url "https://github.com/chrismatix/grog/releases/download/v0.13.0/grog-linux-amd64"
+      sha256 "78fcbac9655c986326d3ef2f1d3ab296b5a175015e05a16b1e846490b680f3bd"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.13.0.

**Changes:**
- Updated version to v0.13.0
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.13.0