### PR TITLE
Update grog to v0.14.2

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.14.1"
+  version "v0.14.2"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.14.1/grog-darwin-arm64"
-      sha256 "6be827423febf26ebbb485a27f3efe2e94e84bef9e110643c69faa12fa04d647"
+      url "https://github.com/chrismatix/grog/releases/download/v0.14.2/grog-darwin-arm64"
+      sha256 "8a03d634d44df30cc14f4aaf6d1759781c645c97bf7b713da0f27c4c04225c84"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.14.1/grog-darwin-amd64"
-      sha256 "f8a3c941dfa6a3f0fd8a2fc9f152c06bb4b066e17b8ce2fddd9cfc407bd256b4"
+      url "https://github.com/chrismatix/grog/releases/download/v0.14.2/grog-darwin-amd64"
+      sha256 "f5775eb7d9323d586cb6e1d1beac703329dd359fa10f4e4e28b92ac7b9dfbde7"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.14.1/grog-linux-arm64"
-      sha256 "10d934719cb1a19bf00310d56c7ea7bb3e03b7faccf4be2e22796df5f9976459"
+      url "https://github.com/chrismatix/grog/releases/download/v0.14.2/grog-linux-arm64"
+      sha256 "ed6413326cd9ca8acdbba85002462ae6a763f94d00458e9f18fae2898bef5488"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.14.1/grog-linux-amd64"
-      sha256 "1231da9378f989a8b96143d29a7eb598c95c1ff1380ee1a0e50548d9416f6f7a"
+      url "https://github.com/chrismatix/grog/releases/download/v0.14.2/grog-linux-amd64"
+      sha256 "0cd18f577d0e8e8272b3316d68def628fb28cc6ea4b10c3c58fa94ee4914a01d"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.14.2.

**Changes:**
- Updated version to v0.14.2
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.14.2