### PR TITLE
Update grog to v0.16.0

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.15.0"
+  version "v0.16.0"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.15.0/grog-darwin-arm64"
-      sha256 "bc09afe843fa851593bfb201c6d0c5e9187c2a0305408b7e237159a0c6e140f9"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-darwin-arm64"
+      sha256 "34a4b8c42f328f2431327fe3d42d318ce94733d2060be5dd2f6913732229e348"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.15.0/grog-darwin-amd64"
-      sha256 "2da057588a61fdd63d7f82b822e932d059387211ccd5d376c84754446d6db867"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-darwin-amd64"
+      sha256 "6a5d7a161b6e2cb20992740345b40d5688bcb9f9c495ab11c62cf1e3df451c71"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.15.0/grog-linux-arm64"
-      sha256 "c0686851b3f37f11c18155c00ac43ce371aa55edf229bee5de2fb129eaca030a"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-linux-arm64"
+      sha256 "49b1d039fe0475e4818031c5d7f55b8dd14b61129a7fc39722e5277378f483fe"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.15.0/grog-linux-amd64"
-      sha256 "b281a12506a719b61a23f312c00b318e4ebf90ad7427e3f0705e18afff7fb9ec"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-linux-amd64"
+      sha256 "9c9fa58c5147199e101373470ddf2edc05c643143db194619fee56565df28d43"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.16.0.

**Changes:**
- Updated version to v0.16.0
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.16.0