### PR TITLE
Update grog to v0.16.2

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.16.0"
+  version "v0.16.2"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-darwin-arm64"
-      sha256 "34a4b8c42f328f2431327fe3d42d318ce94733d2060be5dd2f6913732229e348"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.2/grog-darwin-arm64"
+      sha256 "f70ca49b683b3c5e62be6d9a2947aec1fd2d12234c32816e355c6a282865aceb"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-darwin-amd64"
-      sha256 "6a5d7a161b6e2cb20992740345b40d5688bcb9f9c495ab11c62cf1e3df451c71"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.2/grog-darwin-amd64"
+      sha256 "5dfa0c88d13e49cb9e0b15f55e1422dcfe253609eb6352a1001c20aff7cda4a0"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-linux-arm64"
-      sha256 "49b1d039fe0475e4818031c5d7f55b8dd14b61129a7fc39722e5277378f483fe"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.2/grog-linux-arm64"
+      sha256 "c02b2401a0b0a40fb1acb7dcf3410edb7d1780555b7724c5315c4209b7a907eb"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.16.0/grog-linux-amd64"
-      sha256 "9c9fa58c5147199e101373470ddf2edc05c643143db194619fee56565df28d43"
+      url "https://github.com/chrismatix/grog/releases/download/v0.16.2/grog-linux-amd64"
+      sha256 "b7a8a7bae604b03a76aa5e292daaf58763924ca13d00d06174dffdb8c3acd8d4"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.16.2.

**Changes:**
- Updated version to v0.16.2
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.16.2