### PR TITLE
Update grog to v0.35.0

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.32.0"
+  version "v0.35.0"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.32.0/grog-darwin-arm64"
-      sha256 "6e25ab4b9a34c92cc577566b99f8d58ed204d4c040def846c13d4facb65de8db"
+      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-darwin-arm64"
+      sha256 "029b1abca6032d090c7d975a73e37c15545649a9a1c7c5d8b8a9a45ff43f860e"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.32.0/grog-darwin-amd64"
-      sha256 "6c12bd5394f598b723207786e2292d1a972d87e24a1b8624e2548e8e25fb46a2"
+      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-darwin-amd64"
+      sha256 "c32c155e0d362f5ee35053b02e08af82aed566f2db2423efef9ff05b2e72b8ec"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.32.0/grog-linux-arm64"
-      sha256 "2606cd7882d30b0d05d151848cc7b26b63806e938600f03789725d9633b0432e"
+      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-linux-arm64"
+      sha256 "94dfcdda0c8712f350784f8b4008bf5e2146e4fa49cc8831e526d1a24320c345"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.32.0/grog-linux-amd64"
-      sha256 "66fc2a59fbb4b73d791565893644517fb6a094b5127f03846d5ec841bc0894cf"
+      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-linux-amd64"
+      sha256 "bef66969fd24f536e655665c64638ce5c26bf3ec1d92d3e1d4cd96e7ec7b2681"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.35.0.

**Changes:**
- Updated version to v0.35.0
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.35.0