### PR TITLE
Update grog to v0.36.1

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.35.0"
+  version "v0.36.1"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-darwin-arm64"
-      sha256 "029b1abca6032d090c7d975a73e37c15545649a9a1c7c5d8b8a9a45ff43f860e"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-darwin-arm64"
+      sha256 "0ba1ea22462d70f2da7f396df53ecac06baa1604cc130fc26f3ff936ebdba6aa"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-darwin-amd64"
-      sha256 "c32c155e0d362f5ee35053b02e08af82aed566f2db2423efef9ff05b2e72b8ec"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-darwin-amd64"
+      sha256 "55c8c19d3c05ceef6a77e27a012c5be343012c9ecc5a0178d21b7c2bc8442bc2"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-linux-arm64"
-      sha256 "94dfcdda0c8712f350784f8b4008bf5e2146e4fa49cc8831e526d1a24320c345"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-linux-arm64"
+      sha256 "ba3bb9991dc125f2839b4a542b9baf6745696dfee5439f8100b57e19752f91af"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.35.0/grog-linux-amd64"
-      sha256 "bef66969fd24f536e655665c64638ce5c26bf3ec1d92d3e1d4cd96e7ec7b2681"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-linux-amd64"
+      sha256 "076e97bc6c9e7ad39a14abb64d87a93928596c82e16207b6e6879e76c9f75bd3"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.36.1.

**Changes:**
- Updated version to v0.36.1
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.36.1