### PR TITLE
Update grog to v0.36.6

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.36.1"
+  version "v0.36.6"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-darwin-arm64"
-      sha256 "0ba1ea22462d70f2da7f396df53ecac06baa1604cc130fc26f3ff936ebdba6aa"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-darwin-arm64"
+      sha256 "b5a233e7af8c937d00383897fc19e7df7a4f4393225e708ad03c24c2acf49183"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-darwin-amd64"
-      sha256 "55c8c19d3c05ceef6a77e27a012c5be343012c9ecc5a0178d21b7c2bc8442bc2"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-darwin-amd64"
+      sha256 "8eff059a3d1b2aa27f8dfa4d95152a5279fbe7935685293369719061029022f3"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-linux-arm64"
-      sha256 "ba3bb9991dc125f2839b4a542b9baf6745696dfee5439f8100b57e19752f91af"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-linux-arm64"
+      sha256 "13ebb004f4f8cd94923f244070b66de713262f31226ec55b13791fd72dea52f9"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.1/grog-linux-amd64"
-      sha256 "076e97bc6c9e7ad39a14abb64d87a93928596c82e16207b6e6879e76c9f75bd3"
+      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-linux-amd64"
+      sha256 "d0446819cdafa76f71741f6017e3d056262e2c4abf968678cbe77d29822c6392"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.36.6.

**Changes:**
- Updated version to v0.36.6
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.36.6