### PR TITLE
Update grog to v0.37.0

### DIFF
--- a/Formula/grog.rb
+++ b/Formula/grog.rb
@@ -1,26 +1,26 @@
 class Grog < Formula
   desc "Grog build system CLI"
   homepage "https://github.com/chrismatix/grog"
-  version "v0.36.6"
+  version "v0.37.0"
   license "MIT"  # Update this to match your actual license
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-darwin-arm64"
-      sha256 "b5a233e7af8c937d00383897fc19e7df7a4f4393225e708ad03c24c2acf49183"
+      url "https://github.com/chrismatix/grog/releases/download/v0.37.0/grog-darwin-arm64"
+      sha256 "1b65d869b0c89cce4c90e65aa2439270255543fc150c13194437300b19ff8131"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-darwin-amd64"
-      sha256 "8eff059a3d1b2aa27f8dfa4d95152a5279fbe7935685293369719061029022f3"
+      url "https://github.com/chrismatix/grog/releases/download/v0.37.0/grog-darwin-amd64"
+      sha256 "618d0a3cf5843e911b5e51313400ddc906dce6851c0bfc89e460b4d68d15ed6f"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-linux-arm64"
-      sha256 "13ebb004f4f8cd94923f244070b66de713262f31226ec55b13791fd72dea52f9"
+      url "https://github.com/chrismatix/grog/releases/download/v0.37.0/grog-linux-arm64"
+      sha256 "f0ba6c53418401f18965617b3d82adb8a62566f2f3fb94fd913590c789f0e773"
     else
-      url "https://github.com/chrismatix/grog/releases/download/v0.36.6/grog-linux-amd64"
-      sha256 "d0446819cdafa76f71741f6017e3d056262e2c4abf968678cbe77d29822c6392"
+      url "https://github.com/chrismatix/grog/releases/download/v0.37.0/grog-linux-amd64"
+      sha256 "0e1ddb21067ce2401b6a10df7e94b93500f219d849cf062a15ceae2c1a998980"
     end
   end
 


### PR DESCRIPTION
Automated update of grog formula to version v0.37.0.

**Changes:**
- Updated version to v0.37.0
- Updated SHA256 checksums for all platforms
- Updated download URLs

**Release:** https://github.com/chrismatix/grog/releases/tag/v0.37.0